### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/gui/datamanager.py
+++ b/gui/datamanager.py
@@ -121,7 +121,7 @@ class Plot3DWidget(QWidget,ObserverWidget):
     if ((not plot.xname in self._cube.names()) and plot.xname != "[row number]") or ((not plot.yname in self._cube.names())  and plot.yname != "[row number]"):
       return
     plot.cube = self._cube 
-    plot.legend = "%s, %s vs. %s" % (self._cube.name(),plot.xname,plot.yname)
+    plot.legend = "{0!s}, {1!s} vs. {2!s}".format(self._cube.name(), plot.xname, plot.yname)
     plot.style = 'line'
     if plot.xname != "[row number]":
       xvalues = plot.cube.column(plot.xname)
@@ -406,7 +406,7 @@ class Plot2DWidget(QWidget,ObserverWidget):
     if ((not plot.xname in self._cube.names()) and plot.xname != "[row number]") or ((not plot.yname in self._cube.names())  and plot.yname != "[row number]"):
       return
     plot.cube = self._cube 
-    plot.legend = "%s, %s vs. %s" % (self._cube.name(),plot.xname,plot.yname)
+    plot.legend = "{0!s}, {1!s} vs. {2!s}".format(self._cube.name(), plot.xname, plot.yname)
     plot.style = 'line'
     if plot.xname != "[row number]":
       xvalues = plot.cube.column(plot.xname)

--- a/gui/editor/codeeditor.py
+++ b/gui/editor/codeeditor.py
@@ -134,7 +134,7 @@ class CodeEditorWindow(QWidget):
       currentEditor = self.currentEditor()
       filename = str(QFileDialog.getSaveFileName(filter = "Python(*.py *.pyw)",directory = self.workingDirectory()))
       if filename != "":
-        print "Saving document as %s" % filename
+        print "Saving document as {0!s}".format(filename)
         self.setWorkingDirectory(filename)
         currentEditor.setFilename(filename)
         return self.saveCurrentFile()
@@ -190,8 +190,8 @@ class CodeEditorWindow(QWidget):
         editor.append("")
         editor.activateHighlighter()
       self.editors.append(editor)
-      self.Tab.addTab(editor,"untitled %i" % self.count)
-      self.Tab.setTabToolTip(self.Tab.indexOf(editor),"untitled %i" % self.count)
+      self.Tab.addTab(editor,"untitled {0:d}".format(self.count))
+      self.Tab.setTabToolTip(self.Tab.indexOf(editor),"untitled {0:d}".format(self.count))
       self.connect(editor,SIGNAL("hasUnsavedModifications(bool)"),lambda changed,editor = editor: self.editorHasUnsavedModifications(editor,changed))
       self.count = self.count + 1
       self.Tab.setCurrentWidget(editor)
@@ -224,7 +224,7 @@ class CodeEditorWindow(QWidget):
         messageBox = QMessageBox()
         messageBox.setWindowTitle("Warning!")
         if editor.filename() != None:
-          messageBox.setText("Save changes made to file \"%s\"?" % editor.filename())
+          messageBox.setText("Save changes made to file \"{0!s}\"?".format(editor.filename()))
         else:
           messageBox.setText("Save changes made to this unsaved buffer?")
         yes = messageBox.addButton("Yes",QMessageBox.YesRole)
@@ -275,7 +275,7 @@ class CodeEditorWindow(QWidget):
           return
         MyMessageBox = QMessageBox()
         MyMessageBox.setWindowTitle("Warning!")
-        MyMessageBox.setText("File contents of \"%s\" have changed. Reload?" % editor.filename())
+        MyMessageBox.setText("File contents of \"{0!s}\" have changed. Reload?".format(editor.filename()))
         yes = MyMessageBox.addButton("Yes",QMessageBox.YesRole)
         no = MyMessageBox.addButton("No",QMessageBox.NoRole)
         never = MyMessageBox.addButton("Never",QMessageBox.RejectRole)
@@ -818,7 +818,7 @@ class CodeEditor(SearchableEditor,LineTextWidget):
       
     def highlightLine(self,line):
     
-      print "Highlighting line no %d" % line
+      print "Highlighting line no {0:d}".format(line)
 
       block = self.document().findBlockByLineNumber(line-1)
   
@@ -1122,7 +1122,7 @@ class CodeEditor(SearchableEditor,LineTextWidget):
         self.setFilename(filename)
         self.setHasUnsavedModifications(False)
       else:
-        raise IOError("Invalid path: %s" % filename)
+        raise IOError("Invalid path: {0!s}".format(filename))
            
     def activateBlockHighlighting(self,activate = False):
       self._blockHighlighting = activate

--- a/gui/editor/syntaxhighlighter.py
+++ b/gui/editor/syntaxhighlighter.py
@@ -75,11 +75,11 @@ class Python (QSyntaxHighlighter):
         self.tri_double = (QRegExp('"""'), 2, STYLES['string2'])
 
         rules = []
-        rules += [(r'\b%s\b' % w, 0, STYLES['keyword'])
+        rules += [(r'\b{0!s}\b'.format(w), 0, STYLES['keyword'])
             for w in Python.keywords]
-        rules += [(r'%s' % o, 0, STYLES['operator'])
+        rules += [(r'{0!s}'.format(o), 0, STYLES['operator'])
             for o in Python.operators]
-        rules += [(r'%s' % b, 0, STYLES['brace'])
+        rules += [(r'{0!s}'.format(b), 0, STYLES['brace'])
             for b in Python.braces]
         rules += [
             # Double-quoted string, possibly containing escape sequences

--- a/gui/elements/numericedit.py
+++ b/gui/elements/numericedit.py
@@ -13,7 +13,7 @@ class NumericEdit(QLineEdit):
     return float(self.text())
     
   def setValue(self,value):
-    self.setText("%g" % (value))
+    self.setText("{0:g}".format((value)))
     
   def setRange(self,minimum,maximum):
     pass

--- a/gui/instrumentspanel.py
+++ b/gui/instrumentspanel.py
@@ -75,7 +75,7 @@ class InstrumentsPanel(QWidget,ObserverWidget):
   def reloadInstrument(self):
     selected = self.instrumentlist.selectedItems()
     for instrument in selected:
-      print "Reloading %s" % instrument.text(0)
+      print "Reloading {0!s}".format(instrument.text(0))
       self.manager.reloadInstrument(str(instrument.text(0)))
 
   def showFrontPanel(self):
@@ -104,7 +104,7 @@ class InstrumentsPanel(QWidget,ObserverWidget):
     message.setIcon(QMessageBox.Question) 
     name = str(self.setupList.currentText())
     if name in self._states:
-      message.setText("Do you really want to remove setup \"%s\"?" % name)
+      message.setText("Do you really want to remove setup \"{0!s}\"?".format(name))
       message.setStandardButtons(QMessageBox.Cancel  | QMessageBox.Ok)
       message.setDefaultButton(QMessageBox.Cancel)
       result = message.exec_()
@@ -117,7 +117,7 @@ class InstrumentsPanel(QWidget,ObserverWidget):
     name = str(self.setupList.currentText())
 
     #Sanitize the name of the setup...
-    valid_chars = "-_.() %s%s" % (string.ascii_letters, string.digits)
+    valid_chars = "-_.() {0!s}{1!s}".format(string.ascii_letters, string.digits)
     name = ''.join(c for c in name if c in valid_chars)
 
     if name == "":

--- a/gui/mpl/canvas.py
+++ b/gui/mpl/canvas.py
@@ -104,7 +104,7 @@ class MyMplCanvas(FigureCanvas):
       if event.xdata == None:
         self._moveLabel.hide()
         return
-      self._moveLabel.setText(QString(r"x = %g, y = %g" % (event.xdata,event.ydata)))
+      self._moveLabel.setText(QString(r"x = {0:g}, y = {1:g}".format(event.xdata, event.ydata)))
       self._moveLabel.adjustSize()
       offset = 10
       if self.width()-event.x < self._moveLabel.width():
@@ -129,7 +129,7 @@ class MyMplCanvas(FigureCanvas):
       fontSizeMenu = menu.addMenu("Font size")
       fontSizes = dict()
       for i in range(6,16,2):
-        fontSizes[i] = fontSizeMenu.addAction("%d px" % i)
+        fontSizes[i] = fontSizeMenu.addAction("{0:d} px".format(i))
       action = menu.exec_(self.mapToGlobal(event.pos()))
       if action == saveAsAction:
         filename = QFileDialog.getSaveFileName()
@@ -155,7 +155,7 @@ class MyMplCanvas(FigureCanvas):
         filename += ".pdf"
         cnt = 1
         while os.path.exists(filename):
-          filename = baseName+ "_%d.pdf" % cnt
+          filename = baseName+ "_{0:d}.pdf".format(cnt)
           cnt+=1
         (w,h) = self._fig.get_size_inches()
         try:
@@ -163,7 +163,7 @@ class MyMplCanvas(FigureCanvas):
           if not filename == '':
             self._fig.set_size_inches( self._width, self._height )
             self._fig.savefig(str(filename))
-            url = QUrl("file:///%s" % filename)
+            url = QUrl("file:///{0!s}".format(filename))
             services.openUrl(url)
         finally:
             self._fig.set_size_inches( w,h )
@@ -183,7 +183,7 @@ class MyMplCanvas(FigureCanvas):
         self.autoScale()
       for fontSize in fontSizes.keys():
         if action == fontSizes[fontSize]:
-          print "Setting font size to %d" % fontSize
+          print "Setting font size to {0:d}".format(fontSize)
           rcParams['font.size'] = str(fontSize)
           self.draw()
                          

--- a/gui/objectmodel.py
+++ b/gui/objectmodel.py
@@ -138,7 +138,7 @@ class Converter(object):
   def load(self,params):
     (key,objparams,children) = params
     if not key in self._objectMap:
-      raise KeyError("Don't know how to load objects of type %s" % key)
+      raise KeyError("Don't know how to load objects of type {0!s}".format(key))
     object = self._objectMap[key](**objparams)
     for childparams in children:
       object.addChild(self.load(childparams))

--- a/helpers/coderunner.py
+++ b/helpers/coderunner.py
@@ -295,7 +295,7 @@ class CodeRunner(Reloadable,Subject):
     Executes a code string with a given identifier, filename and local and global variable dictionary.
     """
     if self.isExecutingCode(identifier):
-      raise Exception("Code thread %s is busy!" % identifier)
+      raise Exception("Code thread {0!s} is busy!".format(identifier))
     if lv == None:
       if not identifier in self._lv:
         self._lv[identifier] = dict()
@@ -353,7 +353,7 @@ class CodeProcess(Process):
       if hasattr(self._queue,attr):
         return getattr(self._queue,attr)
       else:
-        raise KeyError("No such attribute: %s" %attr)
+        raise KeyError("No such attribute: {0!s}".format(attr))
     
     def __init__(self,queue):
       self._queue = queue

--- a/helpers/instrumentsmanager.py
+++ b/helpers/instrumentsmanager.py
@@ -112,7 +112,7 @@ class Manager(Subject,Singleton):
     for name in self._instruments.keys():
       try:
         if instruments == [] or name in instruments:
-          print "Storing state of instrument \"%s\"" % name
+          print "Storing state of instrument \"{0!s}\"".format(name)
           state[name] = dict()
           state[name]["state"]=self.getInstrument(name).saveState(stateName)
           if withInitialization:
@@ -120,7 +120,7 @@ class Manager(Subject,Singleton):
             state[name]["kwargs"] = self.handle(name).kwargs()
             state[name]["baseClass"] = self.handle(name).baseClass()
       except:
-        print "Could not save the state of instrument %s:" % name
+        print "Could not save the state of instrument {0!s}:".format(name)
         print traceback.print_exc()
     return state
     
@@ -134,10 +134,10 @@ class Manager(Subject,Singleton):
         self.initInstrument(name,state[name]["baseClass"],state[name]["args"],state[name]["kwargs"])
       if name in self._instruments.keys():
         try:
-          print "Restoring state of instrument \"%s\"" % name
+          print "Restoring state of instrument \"{0!s}\"".format(name)
           self.getInstrument(name).restoreState(state[name]["state"])
         except:
-          print "Could not restore the state of instrument %s:" % name
+          print "Could not restore the state of instrument {0!s}:".format(name)
           print traceback.print_exc()
 
   def parameters(self):
@@ -149,7 +149,7 @@ class Manager(Subject,Singleton):
       try:
         params[name]=self.getInstrument(name).parameters()
       except:
-        print "An error occured when storing the parameters of instrument %s" % name
+        print "An error occured when storing the parameters of instrument {0!s}".format(name)
         print tracebck.print_exc()
     return params
 
@@ -171,11 +171,11 @@ class Manager(Subject,Singleton):
     if handle == None:
       return None
     moduleName = handle._baseClass
-    frontPanelModule =  __import__("frontpanels.%s" % moduleName,globals(),globals(),[moduleName],-1)
+    frontPanelModule =  __import__("frontpanels.{0!s}".format(moduleName),globals(),globals(),[moduleName],-1)
     reload(frontPanelModule)
-    frontPanelModule =  __import__("frontpanels.%s" % moduleName,globals(),globals(),[moduleName],-1)
+    frontPanelModule =  __import__("frontpanels.{0!s}".format(moduleName),globals(),globals(),[moduleName],-1)
     frontPanel = frontPanelModule.Panel(handle._instrument)
-    frontPanel.setWindowTitle("%s front panel" % name)
+    frontPanel.setWindowTitle("{0!s} front panel".format(name))
     return frontPanel
     
   def initRemoteInstrument(self,address,baseclass = None,args = [],kwargs = {},forceReload = False):
@@ -195,7 +195,7 @@ class Manager(Subject,Singleton):
       if result:
         (host,port,name) = result.groups(0)
         try:
-          remoteServer = xmlrpclib.ServerProxy("http://%s:%s" % (host,port))
+          remoteServer = xmlrpclib.ServerProxy("http://{0!s}:{1!s}".format(host, port))
         except socket.error:
           raise
       else:
@@ -227,7 +227,7 @@ class Manager(Subject,Singleton):
     if name.lower() in self._instruments:
       return self._instruments[name.lower()].instrument()
     else:
-      raise AttributeError("Unknown instrument: %s" % name)
+      raise AttributeError("Unknown instrument: {0!s}".format(name))
     
   def _isUrl(self,name):
     if re.match(r'^rip\:\/\/',name) or  re.match(r'^http\:\/\/',name):
@@ -255,7 +255,7 @@ class Manager(Subject,Singleton):
       try:
         self.initInstrument(name = url,baseclass = baseclass,args = args,kwargs = kwargs,**globalParameters)
       except:
-        print "Could not initialize instrument: %s" % url
+        print "Could not initialize instrument: {0!s}".format(url)
         traceback.print_exc()
     
   def initInstrument(self,name,baseclass = None,args = [],kwargs = {},forceReload = False):
@@ -263,7 +263,7 @@ class Manager(Subject,Singleton):
     Loads an instrument. "name" is either the plain name of the instrument to be initialized (e.g. "vna1") or an URL (e.g. "rip://localhost:8000/vna1")
     Returns the reference to the instrument object, or None if the initialization fails.
     """
-    print "Initializing instrument %s" % name
+    print "Initializing instrument {0!s}".format(name)
     if name.lower() in self._instruments:
       if forceReload:
         return self.reloadInstrument(name,args = args,kwargs = kwargs)
@@ -279,9 +279,9 @@ class Manager(Subject,Singleton):
       baseclass = baseclass.lower()
       try:
         if "." in baseclass:
-          instrumentModule = __import__("%s" % baseclass,globals(),globals(),["Instr"],0)
+          instrumentModule = __import__("{0!s}".format(baseclass),globals(),globals(),["Instr"],0)
         else:
-          instrumentModule = __import__("%s%s" % (self._defaultInstrumentsModule,baseclass),globals(),globals(),["Instr"],0)
+          instrumentModule = __import__("{0!s}{1!s}".format(self._defaultInstrumentsModule, baseclass),globals(),globals(),["Instr"],0)
       except:
         raise
       try:
@@ -301,9 +301,9 @@ class Manager(Subject,Singleton):
     Reloads a given instrument.
     """
   
-    print "Reloading %s" %  name
+    print "Reloading {0!s}".format(name)
     if not name.lower() in self._instruments:
-      raise KeyError("No such instrument: %s" % name)
+      raise KeyError("No such instrument: {0!s}".format(name))
 
     handle = self._instruments[name.lower()]
     if handle.instrument().isAlive():
@@ -359,5 +359,5 @@ class RemoteManager():
         return  method(*args,**kwargs)
       else:
         return method
-    raise Exception("Unknown function name: %s" % command)
+    raise Exception("Unknown function name: {0!s}".format(command))
   

--- a/lib/classes.py
+++ b/lib/classes.py
@@ -32,7 +32,7 @@ class Instrument(ThreadedDispatcher,Reloadable,object):
     pass
     
   def __str__(self):
-    return "Instrument \"%s\"" % self.name()
+    return "Instrument \"{0!s}\"".format(self.name())
     
   def saveState(self,name):
     """
@@ -122,7 +122,7 @@ class VisaInstrument(Instrument):
           return lambda *args,**kwargs: self.executeVisaCommand(attr,*args,**kwargs)
         else:
           return attr
-      raise AttributeError("No such attribute: %s" % name)
+      raise AttributeError("No such attribute: {0!s}".format(name))
 
 import pickle
 import cPickle
@@ -182,7 +182,7 @@ class ServerConnection:
       sock.send(command.toString())
       lendata = sock.recv(4)
       if len(lendata) == 0:
-        raise Exception("Connection to server %s port %d failed." % (self._ip,self._port))
+        raise Exception("Connection to server {0!s} port {1:d} failed.".format(self._ip, self._port))
       length = unpack("l",lendata)[0]
       received = sock.recv(length)
       binary = received
@@ -193,7 +193,7 @@ class ServerConnection:
         return None
       response = Command().fromString(binary)
       if response == None:
-        raise Exception("Connection to server %s port %d failed." % (self._ip,self._port))
+        raise Exception("Connection to server {0!s} port {1:d} failed.".format(self._ip, self._port))
       if response.name() == "exception" and len(response.args()) > 0:
         raise response.args()[0]
       return response.args()[0]
@@ -222,7 +222,7 @@ class RemoteInstrument(ThreadedDispatcher,Reloadable,object):
     return result
     
   def __str__(self):
-    return "Remote Instrument \"%s\" on server %s:%d" % (self.name(),self._server.ip(),self._server.port())
+    return "Remote Instrument \"{0!s}\" on server {1!s}:{2:d}".format(self.name(), self._server.ip(), self._server.port())
     
   def name(self):
     """We redefine name, since it is already defined as an attribute in Thread
@@ -233,7 +233,7 @@ class RemoteInstrument(ThreadedDispatcher,Reloadable,object):
     return self.remoteDispatch("__getitem__",[str(key)])
 
   def __setitem__(self,key,value):
-    print "Setting %s" % key
+    print "Setting {0!s}".format(key)
     return self.remoteDispatch("__setitem__",[key,value])
 
   def __delitem__(self,key):

--- a/lib/datacube.py
+++ b/lib/datacube.py
@@ -159,13 +159,13 @@ class Datacube(Subject,Observer,Reloadable):
     """
     Returns a string describing the structure of the datacube
     """
-    string = tabs+"cube(%d,%d)" % (self._meta["length"],len(self._meta["fieldNames"]))+"\n"
+    string = tabs+"cube({0:d},{1:d})".format(self._meta["length"], len(self._meta["fieldNames"]))+"\n"
     for item in self._children:
       child = item.datacube()
       attributes = item.attributes()
       parts = []
       for key in attributes:
-        parts.append((" %s = " % str(key))+str(attributes[key]))
+        parts.append((" {0!s} = ".format(str(key)))+str(attributes[key]))
       string+=", ".join(parts)+":\n"
       string+=child.structure(tabs+"\t")
     return string
@@ -584,7 +584,7 @@ class Datacube(Subject,Observer,Reloadable):
       raise Exception("You must supply a filename!")
     
     if verbose:
-      print "Creating HDF5 file at %s" % path
+      print "Creating HDF5 file at {0!s}".format(path)
     
     dataFile = h5py.File(path,"w")
 
@@ -719,9 +719,9 @@ class Datacube(Subject,Observer,Reloadable):
         item = self._children[i]
         child = item.datacube()
         if child.name() != None:
-          childfilename = basename+"-"+child.name()+("-%d" % (i))
+          childfilename = basename+"-"+child.name()+("-{0:d}".format((i)))
         else:
-          childfilename = basename+("-%d" % (i))
+          childfilename = basename+("-{0:d}".format((i)))
         childPath = child.savetxt(directory+"/"+childfilename,saveChildren = saveChildren,overwrite = True,forceSave = forceSave)
         children.append({'attributes':item.attributes(),'path':childPath})
 

--- a/lib/patterns.py
+++ b/lib/patterns.py
@@ -107,7 +107,7 @@ class Subject:
                   if hasattr(observer(),'updated'):
                     observer().updated(self,property,value)
                 except:
-                  print "An error occured when notifying observer %s." % str(observer())
+                  print "An error occured when notifying observer {0!s}.".format(str(observer()))
                   print sys.exc_info()
                   raise
         for deadObserver in deadObservers:
@@ -215,9 +215,9 @@ class Reloadable(object):
   #This function dynamically reloads the module that defines the class and updates the current instance to the new class.
   def reloadClass(self):
     self.beforeReload()
-    print "Reloading %s" % self.__module__
+    print "Reloading {0!s}".format(self.__module__)
     newModule = reload(sys.modules[self.__module__])
-    self.__class__ = eval("newModule.%s" % self.__class__.__name__)
+    self.__class__ = eval("newModule.{0!s}".format(self.__class__.__name__))
     self.onReload()
     
   def beforeReload(self,*args,**kwargs):

--- a/scripts/acqiris_client_test.py
+++ b/scripts/acqiris_client_test.py
@@ -8,8 +8,8 @@ params = [2,250,2,250,180,0,0,0,0,0]
 for param in params:
 	data+=struct.pack("d",double(param))
 data+='\0'
-print "\"%s\"" %data
-print "Length: %d" % len(data)
+print "\"{0!s}\"".format(data)
+print "Length: {0:d}".format(len(data))
 ##
 # SOCK_DGRAM is the socket type to use for UDP sockets
 for i in range(0,1):
@@ -26,18 +26,18 @@ for i in range(0,1):
 		buffer+=received
 		received = sock.recv(chunk)
 
-	print "Sent:     %s" % data
+	print "Sent:     {0!s}".format(data)
 	strlen = 0
 	print "Done"
 	print type(buffer)
-	print "Buffer length: %d" % len(buffer)
+	print "Buffer length: {0:d}".format(len(buffer))
 	for i in range(0,len(buffer)):
 		code = struct.unpack("B1",buffer[i])[0]
 		if code == 0:
 			print "Found zero!"
 			strlen = i 
 			break
-	print "Length: %d" % strlen
+	print "Length: {0:d}".format(strlen)
 	print len(buffer)
 	print buffer[0:strlen]
 	index0 = strlen
@@ -50,7 +50,7 @@ for i in range(0,1):
 ##
 figure(1)
 cla()
-print "Received %d points" % len(values)
+print "Received {0:d} points".format(len(values))
 scatter(range(0,len(values)),values)
 figure(2)
 cla()

--- a/scripts/acqiris_library_test.py
+++ b/scripts/acqiris_library_test.py
@@ -17,6 +17,6 @@ for i in range(0,10):
   acqiris.bifurcationMap()
   acqiris.bifurcationMap()
   acqiris.bifurcationMap()
-  print "%f seconds elapsed." % ((time.time()-start)/3)
+  print "{0:f} seconds elapsed.".format(((time.time()-start)/3))
 
 MyManager.stop()

--- a/scripts/creole.py
+++ b/scripts/creole.py
@@ -38,9 +38,9 @@ class Rules:
     url =  r'''(?P<url>
             (^ | (?<=\s | [.,:;!?()/=]))
             (?P<escaped_url>~)?
-            (?P<url_target> (?P<url_proto> %s ):\S+? )
+            (?P<url_target> (?P<url_proto> {0!s} ):\S+? )
             ($ | (?=\s | [,.:;!?()] (\s | $)))
-        )''' % proto
+        )'''.format(proto)
     link = r'''(?P<link>
             \[\[
             (?P<link_target>.+?) \s*
@@ -117,9 +117,9 @@ class Rules:
             \| \s*
             (
                 (?P<head> [=][^|]+ ) |
-                (?P<cell> (  %s | [^|])+ )
+                (?P<cell> (  {0!s} | [^|])+ )
             ) \s*
-        ''' % '|'.join([link, macro, image, code])
+        '''.format('|'.join([link, macro, image, code]))
 
 class Parser:
     """
@@ -359,7 +359,7 @@ class Parser:
         groups = match.groupdict()
         for name, text in groups.iteritems():
             if text is not None:
-                replace = getattr(self, '_%s_repl' % name)
+                replace = getattr(self, '_{0!s}_repl'.format(name))
                 replace(groups)
                 return
 

--- a/scripts/creole2html.py
+++ b/scripts/creole2html.py
@@ -137,7 +137,7 @@ from creole import Parser
 class Rules:
     # For the link targets:
     proto = r'http|https|ftp|nntp|news|mailto|telnet|file|irc'
-    extern = r'(?P<extern_addr>(?P<extern_proto>%s):.*)' % proto
+    extern = r'(?P<extern_addr>(?P<extern_proto>{0!s}):.*)'.format(proto)
     interwiki = r'''
             (?P<inter_wiki> [A-Z][a-zA-Z]+ ) :
             (?P<inter_page> .* )
@@ -183,41 +183,41 @@ class HtmlEmitter:
         return u'<hr>';
 
     def paragraph_emit(self, node):
-        return u'<p>%s</p>\n' % self.emit_children(node)
+        return u'<p>{0!s}</p>\n'.format(self.emit_children(node))
 
     def bullet_list_emit(self, node):
-        return u'<ul>\n%s</ul>\n' % self.emit_children(node)
+        return u'<ul>\n{0!s}</ul>\n'.format(self.emit_children(node))
 
     def number_list_emit(self, node):
-        return u'<ol>\n%s</ol>\n' % self.emit_children(node)
+        return u'<ol>\n{0!s}</ol>\n'.format(self.emit_children(node))
 
     def list_item_emit(self, node):
-        return u'<li>%s</li>\n' % self.emit_children(node)
+        return u'<li>{0!s}</li>\n'.format(self.emit_children(node))
 
     def table_emit(self, node):
-        return u'<table>\n%s</table>\n' % self.emit_children(node)
+        return u'<table>\n{0!s}</table>\n'.format(self.emit_children(node))
 
     def table_row_emit(self, node):
-        return u'<tr>%s</tr>\n' % self.emit_children(node)
+        return u'<tr>{0!s}</tr>\n'.format(self.emit_children(node))
 
     def table_cell_emit(self, node):
-        return u'<td>%s</td>' % self.emit_children(node)
+        return u'<td>{0!s}</td>'.format(self.emit_children(node))
 
     def table_head_emit(self, node):
-        return u'<th>%s</th>' % self.emit_children(node)
+        return u'<th>{0!s}</th>'.format(self.emit_children(node))
 
     def emphasis_emit(self, node):
-        return u'<i>%s</i>' % self.emit_children(node)
+        return u'<i>{0!s}</i>'.format(self.emit_children(node))
 
     def strong_emit(self, node):
-        return u'<b>%s</b>' % self.emit_children(node)
+        return u'<b>{0!s}</b>'.format(self.emit_children(node))
 
     def header_emit(self, node):
-        return u'<h%d>%s</h%d>\n' % (
+        return u'<h{0:d}>{1!s}</h{2:d}>\n'.format(
             node.level, self.html_escape(node.content), node.level)
 
     def code_emit(self, node):
-        return u'<tt>%s</tt>' % self.html_escape(node.content)
+        return u'<tt>{0!s}</tt>'.format(self.html_escape(node.content))
 
     def link_emit(self, node):
         target = node.content
@@ -228,11 +228,11 @@ class HtmlEmitter:
         m = self.addr_re.match(target)
         if m:
             if m.group('extern_addr'):
-                return u'<a href="%s">%s</a>' % (
+                return u'<a href="{0!s}">{1!s}</a>'.format(
                     self.attr_escape(target), inside)
             elif m.group('inter_wiki'):
                 raise NotImplementedError
-        return u'<a href="%s">%s</a>' % (
+        return u'<a href="{0!s}">{1!s}</a>'.format(
             self.attr_escape(target), inside)
 
     def image_emit(self, node):
@@ -241,11 +241,11 @@ class HtmlEmitter:
         m = self.addr_re.match(target)
         if m:
             if m.group('extern_addr'):
-                return u'<img src="%s" alt="%s">' % (
+                return u'<img src="{0!s}" alt="{1!s}">'.format(
                     self.attr_escape(target), self.attr_escape(text))
             elif m.group('inter_wiki'):
                 raise NotImplementedError
-        return u'<img src="%s" alt="%s">' % (
+        return u'<img src="{0!s}" alt="{1!s}">'.format(
             self.attr_escape(target), self.attr_escape(text))
 
     def macro_emit(self, node):
@@ -255,7 +255,7 @@ class HtmlEmitter:
         return u"<br>"
 
     def preformatted_emit(self, node):
-        return u"<pre>%s</pre>" % self.html_escape(node.content)
+        return u"<pre>{0!s}</pre>".format(self.html_escape(node.content))
 
     def default_emit(self, node):
         """Fallback function for emitting unknown nodes."""
@@ -270,7 +270,7 @@ class HtmlEmitter:
     def emit_node(self, node):
         """Emit a single node."""
 
-        emit = getattr(self, '%s_emit' % node.kind, self.default_emit)
+        emit = getattr(self, '{0!s}_emit'.format(node.kind), self.default_emit)
         return emit(node)
 
     def emit(self):

--- a/scripts/datacube_test.py
+++ b/scripts/datacube_test.py
@@ -6,7 +6,7 @@ import os.path
 from pyview.lib.datacube import *
 
 def generateSubcube(level = 0):
-  print "Generating subcube at level %d" % level
+  print "Generating subcube at level {0:d}".format(level)
   subcube = Datacube()
   mlist = []
   cnt = 0 

--- a/scripts/elixir_test.py
+++ b/scripts/elixir_test.py
@@ -22,7 +22,7 @@ class DatacubeMapper(Base):
   children = relation('DatacubeMapper', order_by='DatacubeMapper.id', remote_side=[parent_id])
   
   def __repr__(self):
-    return "<%s>" % self.name
+    return "<{0!s}>".format(self.name)
     
 class DatacubeTable(Base):
 

--- a/scripts/latex.py
+++ b/scripts/latex.py
@@ -20,7 +20,7 @@ rules['block'] = rules['no_escape_char']+r'(\{)'
 rules['math'] = rules['no_escape_char']+r'\$'
 
 for rule in rules.keys():
-  print 'rule[%s] = %s' % (rule,rules[rule])
+  print 'rule[{0!s}] = {1!s}'.format(rule, rules[rule])
 
 reflags = re.DOTALL |re.MULTILINE | re.IGNORECASE
 
@@ -93,12 +93,12 @@ class Parser:
       numberedErrorText =''
       linenumber = len(lineNumbers)
       for line in errorText.split('\n'):
-          numberedErrorText+="%d\t:%s\n" % (linenumber,line)
+          numberedErrorText+="{0:d}\t:{1!s}\n".format(linenumber, line)
           linenumber+=1
       testfile = open('test.dat','w')
       testfile.write(parsedText)
       testfile.close()
-      print "Line %d, pos. %d: %s" % (1+len(lineNumbers),len(lineNumbers[len(lineNumbers)-1]),message)
+      print "Line {0:d}, pos. {1:d}: {2!s}".format(1+len(lineNumbers), len(lineNumbers[len(lineNumbers)-1]), message)
       print numberedErrorText
       
   def movePointer(self,remaining):
@@ -273,7 +273,7 @@ class Parser:
       while opening_tags != closing_tags:
         additional = re.match('('+'.*?'+rules['no_escape_char']+closing_tag+')',remaining_string,reflags)
         if additional == None:
-          self.parseError("EOF while scanning for end of %s...%s block!" % (opening_tag,closing_tag))
+          self.parseError("EOF while scanning for end of {0!s}...{1!s} block!".format(opening_tag, closing_tag))
           return (block_string,remaining_string)
         block_string = block_string + additional.string[additional.start(0):additional.end(0)]
         opening_tags = len(re.findall('('+rules['no_escape_char']+opening_tag+')',block_string,reflags)) 

--- a/scripts/multipart.py
+++ b/scripts/multipart.py
@@ -15,19 +15,19 @@ def encode_multipart_formdata(fields, files):
     L = []
     for (key, value) in fields.items():
         L.append('--' + BOUNDARY)
-        L.append('Content-Disposition: form-data; name="%s"' % key)
+        L.append('Content-Disposition: form-data; name="{0!s}"'.format(key))
         L.append('')
         L.append(value)
     if files!= None:
       for (key, filename, value) in files:
           L.append('--' + BOUNDARY)
-          L.append('Content-Disposition: form-data; name="%s"; filename="%s"' % (key, filename))
-          L.append('Content-Type: %s' % get_content_type(filename))
+          L.append('Content-Disposition: form-data; name="{0!s}"; filename="{1!s}"'.format(key, filename))
+          L.append('Content-Type: {0!s}'.format(get_content_type(filename)))
           L.append('')
           L.append(value)
     L.append('--' + BOUNDARY + '--')
     L.append('')
     body = CRLF.join(L)
-    content_type = 'multipart/form-data; boundary=%s' % BOUNDARY
+    content_type = 'multipart/form-data; boundary={0!s}'.format(BOUNDARY)
     return content_type, body
 

--- a/scripts/nodes.py
+++ b/scripts/nodes.py
@@ -218,10 +218,10 @@ class InlineCommandNode(Node):
         if value != None:
           return value
         else:
-          print 'Failed to render \"%s\" node.' % self._command
+          print 'Failed to render \"{0!s}\" node.'.format(self._command)
           return ''
       except AttributeError:
-        return self._renderer.addInline('<%s>%s,%s</%s>' % (self._command,self._arguments,self._optionals,self._command))  
+        return self._renderer.addInline('<{0!s}>{1!s},{2!s}</{3!s}>'.format(self._command, self._arguments, self._optionals, self._command))  
 
 class BlockCommandNode(Node):
 
@@ -279,9 +279,9 @@ class BlockCommandNode(Node):
         return attr()
       except AttributeError:
         if self._innerLatex != None:
-          return self._renderer.addBlock('<%s>%s,%s,%s</%s>' % (self._command,self._arguments,self._optionals,self._innerLatex.render(format),self._command))  
+          return self._renderer.addBlock('<{0!s}>{1!s},{2!s},{3!s}</{4!s}>'.format(self._command, self._arguments, self._optionals, self._innerLatex.render(format), self._command))  
         else:
-          return self._renderer.addBlock('<%s>%s,%s,%s</%s>' % (self._command,self._arguments,self._optionals,self._block,self._command))  
+          return self._renderer.addBlock('<{0!s}>{1!s},{2!s},{3!s}</{4!s}>'.format(self._command, self._arguments, self._optionals, self._block, self._command))  
         
 class TextNode(Node):
 

--- a/scripts/remote_dispatcher_test.py
+++ b/scripts/remote_dispatcher_test.py
@@ -19,7 +19,7 @@ class MwgObserver:
     print "Attached..."
     
   def updated(self,subject,property = None,value = None):
-    print "Property %s got updated!" % property
+    print "Property {0!s} got updated!".format(property)
 
 o = MwgObserver(mwg)
 

--- a/scripts/socket_server_test.py
+++ b/scripts/socket_server_test.py
@@ -43,7 +43,7 @@ class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
       if m == None:
         return
       if DEBUG:
-        print "Received command: %s" % m.name()
+        print "Received command: {0!s}".format(m.name())
       if hasattr(self.manager,m.name()):
         method = getattr(self.manager,m.name())
         try:
@@ -51,9 +51,9 @@ class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
           returnMessage = Command(name = "return",args = [result])
           self.request.send(returnMessage.toString())
         except Exception as exception:
-          print "An exception occured:%s"% str(exception)
-          print "args: %s" % str(m.args())
-          print "kwargs: %s" % str(m.kwargs())
+          print "An exception occured:{0!s}".format(str(exception))
+          print "args: {0!s}".format(str(m.args()))
+          print "kwargs: {0!s}".format(str(m.kwargs()))
           returnMessage = Command(name = "exception",args = [exception])
           self.request.send(returnMessage.toString())
 
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     server = ThreadedTCPServer((HOST, PORT), ThreadedTCPRequestHandler)
     ip, port = server.server_address
   
-    print "Running on ip %s, port %d" % (ip,port)
+    print "Running on ip {0!s}, port {1:d}".format(ip, port)
 
     server_thread = threading.Thread(target=server.serve_forever)
 

--- a/scripts/sweep_test.py
+++ b/scripts/sweep_test.py
@@ -41,13 +41,13 @@ while True:
 		vals1[:,0] = freqs1
 		vals1[:,1] = mag1
 		vals1[:,2] = phase1
-		savetxt("vna1-%d_%d.txt" % (globalIndex,cnt),vals1)		
+		savetxt("vna1-{0:d}_{1:d}.txt".format(globalIndex, cnt),vals1)		
 
 		vals2 = zeros((len(freqs2),3))
 		vals2[:,0] = freqs2
 		vals2[:,1] = mag2
 		vals2[:,2] = phase2
-		savetxt("vna2-%d_%d.txt" % (globalIndex,cnt),vals2)		
+		savetxt("vna2-{0:d}_{1:d}.txt".format(globalIndex, cnt),vals2)		
 
 		temp = tempSensor.temperature()
 		t = time.time()
@@ -59,8 +59,8 @@ while True:
 		data[cnt,4]=l2 
 		data[cnt,5]=mag1[len(mag1)/2]
 		data[cnt,6]=mag2[len(mag2)/2]
-		print "%d, T: %f, L1: %f, L2: %f, M1: %f, M2: %f" % (cnt,temp,l1,l2,mag1[len(mag1)/2],mag2[len(mag2)/2])
-		savetxt("cooldown-electrical-length-%d.txt" % globalIndex,data)
+		print "{0:d}, T: {1:f}, L1: {2:f}, L2: {3:f}, M1: {4:f}, M2: {5:f}".format(cnt, temp, l1, l2, mag1[len(mag1)/2], mag2[len(mag2)/2])
+		savetxt("cooldown-electrical-length-{0:d}.txt".format(globalIndex),data)
 		cnt+=1
 	except SystemExit:
 		print "Exiting..."

--- a/scripts/test_datacube.py
+++ b/scripts/test_datacube.py
@@ -16,4 +16,4 @@ if cube != newcube:
 else:
 	print "Cubes are equal!"
 
-print "Elaspsed time: %g s" % (time.time()-start)
+print "Elaspsed time: {0:g} s".format((time.time()-start))

--- a/scripts/xml_test.py
+++ b/scripts/xml_test.py
@@ -173,7 +173,7 @@ class XmlConverter(object):
 		objectNode = node
 		key = objectNode.nodeName
 		if not key in self._objectMap:
-			raise KeyError("Don't know how to load objects of type %s" % key)
+			raise KeyError("Don't know how to load objects of type {0!s}".format(key))
 		object = self._objectMap[key].fromXml(document,objectNode)
 		childrenNode = objectNode.getElementsByTagName("children")[0]
 		for childNode in childrenNode.childNodes:

--- a/scripts/xmlrpc_client_test.py
+++ b/scripts/xmlrpc_client_test.py
@@ -26,7 +26,7 @@ mwg = RemoteInstrument(s,"qubit1mwg","anritsu_mwg",[],{'name' : 'Qubit 1','visaA
 mwg.start()
 print mwg.setFrequency(5.0)
 mwg.reloadInstrument()
-print "Qubit 1 frequency: %g " % mwg.frequency()
+print "Qubit 1 frequency: {0:g} ".format(mwg.frequency())
 
 #The Acqiris card
 #acqiris = RemoteInstrument(s,"acqiris","acqiris",kwargs = {'name': 'Acqiris Card'})

--- a/scripts/xyplot.py
+++ b/scripts/xyplot.py
@@ -193,7 +193,7 @@ class XYPlot(QLabel):
         cnt+=1
         lastSlope = slope
       lastPoint = currentPoint
-    print cnt," points used (instead of %d)." % len(scanRange)
+    print cnt," points used (instead of {0:d}).".format(len(scanRange))
     Path.lineTo(currentPoint)
     while len(self.transformedPoints) <= i:
       self.transformedPoints.append(QPainterPath())
@@ -253,7 +253,7 @@ class XYPlot(QLabel):
     ticks = generateTicks(viewRect.left(),viewRect.right(),8)
 
     for tick in ticks:
-      text = "%g" % tick
+      text = "{0:g}".format(tick)
       screenCoordinate = self.screenX(tick)
       rect = metrics.boundingRect(text)
       painter.drawText(screenCoordinate-rect.width()/2.0,self.height()*(1.0-self.borderY)+ rect.height(),text)
@@ -261,7 +261,7 @@ class XYPlot(QLabel):
     ticks = generateTicks(viewRect.top(),viewRect.bottom(),7)
 
     for tick in ticks:
-      text = "%g" % tick
+      text = "{0:g}".format(tick)
       screenCoordinate = self.screenY(tick)
       rect = metrics.boundingRect(text)
       painter.drawText(0,screenCoordinate-rect.height()/2,self.width()*self.borderX-4,rect.height(),Qt.AlignRight,text)

--- a/server/pickle_server.py
+++ b/server/pickle_server.py
@@ -43,7 +43,7 @@ class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
         if m == None:
           return
         if DEBUG:
-          print "Received command: %s" % m.name()
+          print "Received command: {0!s}".format(m.name())
         if hasattr(self.manager,m.name()):
           method = getattr(self.manager,m.name())
           try:
@@ -52,9 +52,9 @@ class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
             self.request.send(returnMessage.toString())
           except Exception as exception:
             print "An exception occured:"
-            print "name: %s" % str(m.name())
-            print "args: %s" % str(m.args())
-            print "kwargs: %s" % str(m.kwargs())
+            print "name: {0!s}".format(str(m.name()))
+            print "args: {0!s}".format(str(m.args()))
+            print "kwargs: {0!s}".format(str(m.kwargs()))
             print "-"*40
             traceback.print_exc()
             print "-"*40
@@ -86,7 +86,7 @@ def startServer():
     server = ThreadedTCPServer((HOST, PORT), ThreadedTCPRequestHandler)
     ip, port = server.server_address
   
-    print "Running on ip %s, port %d" % (ip,port)
+    print "Running on ip {0!s}, port {1:d}".format(ip, port)
 
     server_thread = threading.Thread(target=server.serve_forever)
 

--- a/test/lib/__init__.py
+++ b/test/lib/__init__.py
@@ -36,7 +36,7 @@ def autotest():
         sys.exit(2)
 
 def testinfo():
-    print "%d tests disabled" % common.skipped
+    print "{0:d} tests disabled".format(common.skipped)
     
 if __name__ == '__main__':
   runtests()

--- a/test/lib/test_datacube.py
+++ b/test/lib/test_datacube.py
@@ -101,7 +101,7 @@ class TestDatacubeIO(unittest.TestCase):
     for i in range(0,2):
       rc.set(x = i,y = i*i, z = i*i*i,r = random.random())
       child = Datacube()
-      child.setName("test %d" % i)
+      child.setName("test {0:d}".format(i))
       rc.addChild(child)
       rc.commit()
       for j in range(0,2):
@@ -122,7 +122,7 @@ class TestDatacubeIO(unittest.TestCase):
     for i in range(0,2):
       cx.set(x = i,y = i*i*1j+4, z = i*i*i*1j,r = 1j*random.random())
       child = Datacube(dtype = numpy.complex128)
-      child.setName("test %d" % i)
+      child.setName("test {0:d}".format(i))
       cx.addChild(child)
       cx.commit()
       for j in range(0,2):
@@ -138,12 +138,12 @@ class TestDatacubeIO(unittest.TestCase):
     Test saving a datacube to a HDF5 file
     """
     for key in self.testCubes.keys():
-      print "Checking HDF5 loading of test cube %s" % key
+      print "Checking HDF5 loading of test cube {0!s}".format(key)
       cube = self.testCubes[key]
-      filename = os.path.normpath(self.dataPath+"/test_%s.hdf5" % key)
+      filename = os.path.normpath(self.dataPath+"/test_{0!s}.hdf5".format(key))
       cube.saveToHdf5(filename,overwrite = True)
       
-      self.assert_(os.path.exists(filename),"File %s has not been created!" % filename)
+      self.assert_(os.path.exists(filename),"File {0!s} has not been created!".format(filename))
       self.assert_(os.path.isfile(filename))
       
       restoredCube = Datacube()
@@ -156,12 +156,12 @@ class TestDatacubeIO(unittest.TestCase):
     Test saving a datacube to a text file
     """
     for key in self.testCubes.keys():
-      print "Checking plain text loading of test cube %s" % key
+      print "Checking plain text loading of test cube {0!s}".format(key)
       cube = self.testCubes[key]
-      filename = os.path.normpath(self.dataPath+"/test_%s.txt" % key)
+      filename = os.path.normpath(self.dataPath+"/test_{0!s}.txt".format(key))
       cube.savetxt(filename,overwrite = True)
       
-      self.assert_(os.path.exists(filename),"File %s has not been created!" % filename)
+      self.assert_(os.path.exists(filename),"File {0!s} has not been created!".format(filename))
       self.assert_(os.path.isfile(filename))
       
       restoredCube = Datacube()
@@ -174,12 +174,12 @@ class TestDatacubeIO(unittest.TestCase):
     Test saving a datacube to a binary file
     """
     for key in self.testCubes.keys():
-      print "Checking binary loading of test cube %s" % key
+      print "Checking binary loading of test cube {0!s}".format(key)
       cube = self.testCubes[key]
-      filename = os.path.normpath(self.dataPath+"/test_%s.dat" % key)
+      filename = os.path.normpath(self.dataPath+"/test_{0!s}.dat".format(key))
       cube.save(filename)
       
-      self.assert_(os.path.exists(filename),"File %s has not been created!" % filename)
+      self.assert_(os.path.exists(filename),"File {0!s} has not been created!".format(filename))
       self.assert_(os.path.isfile(filename))
       
       restoredCube = Datacube()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:adewes:pyview?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:adewes:pyview?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
